### PR TITLE
no longer re-issue dock when squad is already partially docked

### DIFF
--- a/Data/scripts/playerspatch_patches.lua
+++ b/Data/scripts/playerspatch_patches.lua
@@ -78,15 +78,17 @@ function inhibitHyperspaceGlobal()
 end
 
 function PlayersPatch_UnderAttackReissueDock(group)
-    if (SobGroup_GetCurrentOrder(group) == COMMAND_Dock) then -- docking
-        if (SobGroup_UnderAttack(group)) then -- under attack
-            if (SobGroup_Count(group) < SobGroup_GetStaticF(group, "buildBatch")) then -- lost one or more members
-                if (SobGroup_GetActualSpeed(group) < 50) then -- probably bugged into stopping - could get unlucky here and catch a pivoting squad
-                    SobGroup_DockSobGroupWithAny(group)
-                end
-            end
-        end
-    end
+	if (SobGroup_IsDocked(group) == 0) then -- no member of this squad is docked
+		if (SobGroup_GetCurrentOrder(group) == COMMAND_Dock) then -- en route to dock
+			if (SobGroup_UnderAttack(group)) then -- under attack
+				if (SobGroup_Count(group) < SobGroup_GetStaticF(group, "buildBatch")) then -- lost one or more members
+					if (SobGroup_GetActualSpeed(group) < 50) then -- probably bugged into stopping - could get unlucky here and catch a pivoting squad
+						SobGroup_DockSobGroupWithAny(group)
+					end
+				end
+			end
+		end
+	end
 end
 
 -- tech exposure (2.4) [Fear]


### PR DESCRIPTION
`CustomGroup` is the entire squad -> `SobGroup_IsDocked` will return `1` if any member is already docked, so short circuit on this first